### PR TITLE
Fix TLS leaf cleanup on thread exit

### DIFF
--- a/crypto/threads_common.c
+++ b/crypto/threads_common.c
@@ -169,8 +169,15 @@ static CRYPTO_ONCE master_once = CRYPTO_ONCE_STATIC_INIT;
  * @param arg
  *        Unused parameter.
  */
+static void clean_ctx_entry(ossl_uintmax_t idx, CTX_TABLE_ENTRY *ctxentry,
+                            void *arg)
+{
+    OPENSSL_free(*ctxentry);
+}
+
 static void clean_master_key_id(MASTER_KEY_ENTRY *entry)
 {
+    ossl_sa_CTX_TABLE_ENTRY_doall_arg(entry->ctx_table, clean_ctx_entry, NULL);
     ossl_sa_CTX_TABLE_ENTRY_free(entry->ctx_table);
 }
 


### PR DESCRIPTION
## Summary
- free thread-local data entries when cleaning master key tables

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6859a60c31688327b6c12494fa7f22de